### PR TITLE
Avoid triggering rate limits with yfinance

### DIFF
--- a/TradeSim/utils.py
+++ b/TradeSim/utils.py
@@ -25,6 +25,7 @@ from control import (
 )
 from helper_files.client_helper import get_ndaq_tickers, strategies
 from helper_files.train_client_helper import get_historical_data
+from utils.session import limiter
 
 # from strategies.talib_indicators import *
 
@@ -91,6 +92,7 @@ def initialize_simulation(
             interval="1d",
             group_by="ticker",
             threads=True,
+            session=limiter,
         )
     except Exception as bulk_err:
         logger.error(f"Bulk download failed: {str(bulk_err)}")
@@ -120,7 +122,9 @@ def initialize_simulation(
                 f"Error retrieving specific date range for {ticker} via bulk download, fetching max available data. Error: {str(e)}"
             )
             try:
-                ticker_data = yf.Ticker(ticker).history(period="max", interval="1d")
+                ticker_data = yf.Ticker(ticker, session=limiter).history(
+                    period="max", interval="1d"
+                )
                 if ticker_data.empty:
                     logger.warning(
                         f"No data available for {ticker} even for max period."

--- a/helper_files/client_helper.py
+++ b/helper_files/client_helper.py
@@ -145,6 +145,7 @@ from strategies.talib_indicators import (
     WILLR_indicator,
     WMA_indicator,
 )
+from utils.session import limiter
 
 sys.path.append("..")
 
@@ -456,7 +457,7 @@ def get_latest_price(ticker):
     :return: The latest price of the stock
     """
     try:
-        ticker_yahoo = yf.Ticker(ticker)
+        ticker_yahoo = yf.Ticker(ticker, session=limiter)
         data = ticker_yahoo.history()
 
         return round(data["Close"].iloc[-1], 2)
@@ -480,7 +481,7 @@ def dynamic_period_selector(ticker):
 
     for period in periods:
         try:
-            data = yf.Ticker(ticker).history(period=period)
+            data = yf.Ticker(ticker, session=limiter).history(period=period)
             if data.empty:
                 continue
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ polygon-api-client
 pymongo
 certifi
 alpaca-py
-yfinance
+yfinance[nospam]
 scipy
 pandas
 cython

--- a/strategies/talib_indicators.py
+++ b/strategies/talib_indicators.py
@@ -7,6 +7,7 @@ import talib as ta
 import yfinance as yf
 
 from control import trade_asset_limit
+from utils.session import limiter
 
 sys.path.append("..")
 
@@ -26,7 +27,7 @@ def get_data(ticker, mongo_client, period=None, start_date=None, end_date=None):
                     df.set_index("Date", inplace=True)
                     return df
                 else:
-                    ticker_obj = yf.Ticker(ticker)
+                    ticker_obj = yf.Ticker(ticker, session=limiter)
                     data = ticker_obj.history(period=period)
 
                     records = data.reset_index().to_dict("records")
@@ -43,7 +44,9 @@ def get_data(ticker, mongo_client, period=None, start_date=None, end_date=None):
         return data
     else:
         try:
-            return yf.Ticker(ticker).history(start=start_date, end=end_date)
+            return yf.Ticker(ticker, session=limiter).history(
+                start=start_date, end=end_date
+            )
         except Exception as e:
             print(f"Error fetching data for {ticker}: {e}")
             time.sleep(10)

--- a/utils/session.py
+++ b/utils/session.py
@@ -1,0 +1,4 @@
+from pyrate_limiter import Duration, Limiter, RequestRate
+from requests_ratelimiter import LimiterSession
+
+limiter = LimiterSession(limiter=Limiter(RequestRate(2, Duration.SECOND)))


### PR DESCRIPTION
Use a centralized session configuration to manage requests and avoid Yahoo rate-limiter/blocker, that can corrupt data.

Closes #111 